### PR TITLE
feat: Drag And Drop 시간표 수정/삭제 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,24 @@
-
 import { RouterProvider } from "react-router-dom";
 import { GlobalStyle } from "./style/global";
 import { router } from "./router";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      cacheTime: 1000 * 60 * 5,
+      staleTime: 1000 * 60,
+    },
+  },
+});
 
 function App() {
   return (
     <>
-      <GlobalStyle />
-      <RouterProvider router={router}></RouterProvider>
+      <QueryClientProvider client={queryClient}>
+        <GlobalStyle />
+        <RouterProvider router={router}></RouterProvider>
+      </QueryClientProvider>
     </>
   );
 }

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { getToken, removeToken } from "../store/authStore";
-export const BASE_URL = "http://localhost:3001/api";
+export const BASE_URL =
+  "http://ec2-13-209-84-47.ap-northeast-2.compute.amazonaws.com:3001/api";
 const DEFAULT_TIMEOUT = 20000;
 
 const createDefaultInstance = (config?: AxiosRequestConfig) => {
@@ -45,9 +46,11 @@ authInstance.interceptors.response.use(
           break;
         case 404:
           return Promise.resolve({ data: [] });
+        case 409:
+          return alert(error.response.data.message);
+        case 304:
+          return alert(`이전과 동일한 스케줄입니다.`);
         default:
-          console.error("Error status:", error.response.status);
-          console.error("Error data:", error.response.data);
           break;
       }
     } else {

--- a/src/api/schedule.api.ts
+++ b/src/api/schedule.api.ts
@@ -5,7 +5,6 @@ export const fetchScheduledLectures = async () => {
     const response = await authInstance.get(`/scheduled-lectures`);
     return response.data;
   } catch (error) {
-    console.log(error);
     throw error;
   }
 };

--- a/src/api/schedule.api.ts
+++ b/src/api/schedule.api.ts
@@ -1,9 +1,11 @@
 import { authInstance } from "./http";
 
 export const fetchScheduledLectures = async () => {
-  const response = await authInstance.get(`/scheduled-lectures`);
-  if (response) {
+  try {
+    const response = await authInstance.get(`/scheduled-lectures`);
     return response.data;
+  } catch (error) {
+    console.log(error);
+    throw error;
   }
-  return [];
 };

--- a/src/api/scheduled.api.ts
+++ b/src/api/scheduled.api.ts
@@ -35,9 +35,11 @@ export const fetchGetScheduled = async () => {
 };
 
 export const fetchUpdateScheduled = async (data: UpdateProps) => {
-  await authInstance.put(`schedule-lectures/${data.lectureID}`);
+  console.log(data);
+
+  await authInstance.put(`scheduled-lectures/${data.lectureID}`, data);
 };
 
 export const fetchDeleteScheduled = async (lectureID: number) => {
-  await authInstance.delete(`schedule-lectures/${lectureID}`);
+  await authInstance.delete(`scheduled-lectures/${lectureID}`);
 };

--- a/src/api/scheduled.api.ts
+++ b/src/api/scheduled.api.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { ScheduledLecture } from "../models/scheduled.model";
 import { authInstance } from "./http";
+import { UpdateProps } from "../components/TableContents";
 
 export const fetchAddScheduled = async (data: ScheduledLecture) => {
   try {
@@ -12,9 +13,6 @@ export const fetchAddScheduled = async (data: ScheduledLecture) => {
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (error.response) {
-        console.error("Error status:", error.response.status);
-        console.error("Error data:", error.response.data);
-
         if (error.response.status === 409) {
           return error.response.data.message;
         } else {
@@ -34,4 +32,12 @@ export const fetchAddScheduled = async (data: ScheduledLecture) => {
 export const fetchGetScheduled = async () => {
   const response = await authInstance.get(`scheduled-lectures`);
   return response ? response.data.data : [];
+};
+
+export const fetchUpdateScheduled = async (data: UpdateProps) => {
+  await authInstance.put(`schedule-lectures/${data.lectureID}`);
+};
+
+export const fetchDeleteScheduled = async (lectureID: number) => {
+  await authInstance.delete(`schedule-lectures/${lectureID}`);
 };

--- a/src/api/scheduled.api.ts
+++ b/src/api/scheduled.api.ts
@@ -32,10 +32,6 @@ export const fetchAddScheduled = async (data: ScheduledLecture) => {
 };
 
 export const fetchGetScheduled = async () => {
-  try {
-    const response = await authInstance.get(`scheduled-lectures`);
-    return response ? response.data.data : [];
-  } catch (error) {
-    return [];
-  }
+  const response = await authInstance.get(`scheduled-lectures`);
+  return response ? response.data.data : [];
 };

--- a/src/api/scheduled.api.ts
+++ b/src/api/scheduled.api.ts
@@ -36,7 +36,6 @@ export const fetchGetScheduled = async () => {
 
 export const fetchUpdateScheduled = async (data: UpdateProps) => {
   console.log(data);
-
   await authInstance.put(`scheduled-lectures/${data.lectureID}`, data);
 };
 

--- a/src/components/MyLectureList.tsx
+++ b/src/components/MyLectureList.tsx
@@ -10,10 +10,6 @@ import { mockLectureData } from "../mock/lecture";
 import Button from "./common/Button";
 import { useNavigate } from "react-router-dom";
 
-interface Props {
-  onDragStart: (lecture: Lecture) => (event: DragEvent) => void;
-}
-
 export default function MyLectureList() {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState<boolean>(false);

--- a/src/components/MyTimeTable.tsx
+++ b/src/components/MyTimeTable.tsx
@@ -10,7 +10,7 @@ export type Schedule = {
   [day: string]: string[];
 };
 
-export default function MyTimeTable({}: any) {
+export default function MyTimeTable() {
   const { scheduledLectures } = useSchedules();
   const schedule = initializeSchedule();
 

--- a/src/components/MyTimeTable.tsx
+++ b/src/components/MyTimeTable.tsx
@@ -1,30 +1,16 @@
 import styled from "styled-components";
 import { theme } from "../style/theme";
-import { DragEvent, useEffect, useState } from "react";
-import { ScheduledLectureFormat, formatScheduled } from "../utils/format";
 import { days, hours, initializeSchedule } from "../utils/timeTable";
 import { useSchedules } from "../hooks/useSchedules";
 import TableHeader from "./TableHeader";
 import TableContainer from "./TableContainer";
-import TableCell from "./TableCell";
 import TableContents from "./TableContents";
 
 export type Schedule = {
   [day: string]: string[];
 };
 
-interface TableCellProps {
-  howLong: number;
-  startPoint: number;
-}
-
-interface Props {
-  onDragOver: (event: DragEvent<HTMLTableCellElement>) => void;
-  onDrop: (event: DragEvent<HTMLTableCellElement>) => void;
-}
-
-export default function MyTimeTable({ onDragStart, onDragOver, onDrop }: any) {
-  const dropHandler = onDrop();
+export default function MyTimeTable({}: any) {
   const { scheduledLectures } = useSchedules();
   const schedule = initializeSchedule();
 
@@ -45,6 +31,7 @@ export default function MyTimeTable({ onDragStart, onDragOver, onDrop }: any) {
 // 스타일 컴포넌트
 const MyTimeTableStyle = styled.div`
   width: 70%;
+  position: relative;
   table {
     width: 100%;
     border-collapse: collapse;
@@ -56,13 +43,45 @@ const MyTimeTableStyle = styled.div`
     text-align: center;
     position: relative;
   }
+  .hoverd {
+    background-color: aliceblue;
+  }
   th {
     background-color: #f2f2f2;
   }
   p {
     margin: 0;
   }
-  .TableData {
+
+  @keyframes fade-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+  &.fade-in {
+    animation: fade-in 0.3s ease-in-out forwards;
+  }
+
+  &.fade-out {
+    animation: fade-out 0.3s ease-in-out forwards;
+  }
+  .modal {
+    position: absolute;
+    display: flex;
+    padding: 50px;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+    border-radius: ${theme.borderRadius.default};
+    transform: translate(-50%, -50%);
+    top: 50%;
+    left: 50%;
+    background-color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 100px;
   }
 `;
 

--- a/src/components/ScheduleModal.tsx
+++ b/src/components/ScheduleModal.tsx
@@ -1,20 +1,16 @@
 import styled from "styled-components";
 import Button from "./common/Button";
 import { Modal } from "./common/Modal";
+import React from "react";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   isSchedule: boolean;
-  handleClick: (event: any) => void;
+  handleClick: (event: React.FormEvent<HTMLButtonElement>) => void;
 }
 
-export default function ScheduleModal({
-  isOpen,
-  onClose,
-  isSchedule,
-  handleClick,
-}: Props) {
+export default function ScheduleModal({ isOpen, onClose, handleClick }: Props) {
   return (
     <>
       <Modal isOpen={isOpen} onClose={onClose} isSchedule={true}>

--- a/src/components/ScheduleModal.tsx
+++ b/src/components/ScheduleModal.tsx
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+import Button from "./common/Button";
+import { Modal } from "./common/Modal";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  isSchedule: boolean;
+  handleClick: (event: any) => void;
+}
+
+export default function ScheduleModal({
+  isOpen,
+  onClose,
+  isSchedule,
+  handleClick,
+}: Props) {
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose} isSchedule={true}>
+        <ButtonBox>
+          <Button
+            value={"0"}
+            scheme="primary"
+            size="medium"
+            onClick={handleClick}
+          >
+            시작시간: 00분
+          </Button>
+          <Button
+            scheme="primary"
+            size="medium"
+            value={"0.5"}
+            onClick={handleClick}
+          >
+            시작시간: 30분
+          </Button>
+        </ButtonBox>
+      </Modal>
+    </>
+  );
+}
+
+const ButtonBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  button {
+    margin-top: 10px;
+  }
+`;

--- a/src/components/Scheduling.tsx
+++ b/src/components/Scheduling.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useSelected } from "../hooks/useSelected";
 import { ScheduledLecture } from "../models/scheduled.model";
 import { fetchAddScheduled, fetchGetScheduled } from "../api/scheduled.api";
+import { useQueryClient } from "react-query";
 
 interface Props {
   lecture: Lecture;
@@ -21,7 +22,7 @@ export default function Scheduling({ lecture, onClose }: Props) {
   const endTimeOptions = generateTimeOptions(6.5, 24);
 
   //   console.log(lecture);
-
+  const queryClient = useQueryClient();
   const handleAdd = () => {
     const baseDate = "2000-01-01";
     const startDateTime = new Date(`${baseDate}T${startTime}:00`);
@@ -43,9 +44,9 @@ export default function Scheduling({ lecture, onClose }: Props) {
         };
         fetchAddScheduled(data).then((message) => {
           alert(message);
+          queryClient.invalidateQueries(`schedules`);
           onClose();
         });
-        // 여기서 추가한 후 캐싱을 하면 useScheduled는 캐싱된 데이터를 받아오면됨
       }
     });
   };

--- a/src/components/TableCell.tsx
+++ b/src/components/TableCell.tsx
@@ -4,7 +4,7 @@ import {
   calculateHowLong,
   calculateStartPoint,
 } from "../utils/format";
-import { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { DragAndDropContext } from "../context/DragAndDrop";
 
 interface Props {
@@ -23,7 +23,17 @@ export default function TableCell({
   hourIndex,
   dayIndex,
 }: Props) {
-  const { handleDragStart } = useContext(DragAndDropContext);
+  const { handleDragStart, isDraging } = useContext(DragAndDropContext);
+  const handleDragStartWrapper = (lecture: ScheduledLectureFormat) => {
+    return (event: React.DragEvent<HTMLDivElement>) => {
+      handleDragStart({
+        howLong: calculateHowLong(lecture),
+        lectureID: lecture.lectureID,
+        weekDayID: 0,
+        startAt: 0,
+      })(event);
+    };
+  };
 
   return (
     <>
@@ -35,12 +45,7 @@ export default function TableCell({
             howlong={calculateHowLong(lecture)}
             startpoint={calculateStartPoint(lecture)}
             draggable={true}
-            onDragStart={handleDragStart({
-              howLong: calculateHowLong(lecture),
-              lectureID: lecture.lectureID,
-              weekDayID: 0,
-              startAt: 0,
-            })}
+            onDragStart={handleDragStartWrapper(lecture)}
           >
             {lecture.title}
           </TableCellStyled>
@@ -61,4 +66,5 @@ const TableCellStyled = styled.div<TableCellProps>`
   display: flex;
   justify-content: center;
   align-items: center;
+  font-size: 11px;
 `;

--- a/src/components/TableCell.tsx
+++ b/src/components/TableCell.tsx
@@ -1,4 +1,4 @@
-import styled, { keyframes } from "styled-components";
+import styled from "styled-components";
 import {
   ScheduledLectureFormat,
   calculateHowLong,
@@ -8,7 +8,7 @@ import { useContext } from "react";
 import { DragAndDropContext } from "../context/DragAndDrop";
 
 interface Props {
-  scheduledLectures?: ScheduledLectureFormat[];
+  scheduledLectures: ScheduledLectureFormat[];
   hourIndex: number;
   dayIndex: number;
 }
@@ -38,6 +38,8 @@ export default function TableCell({
             onDragStart={handleDragStart({
               howLong: calculateHowLong(lecture),
               lectureID: lecture.lectureID,
+              weekDayID: 0,
+              startAt: 0,
             })}
           >
             {lecture.title}

--- a/src/components/TableCell.tsx
+++ b/src/components/TableCell.tsx
@@ -1,5 +1,11 @@
-import styled from "styled-components";
-import { ScheduledLectureFormat } from "../utils/format";
+import styled, { keyframes } from "styled-components";
+import {
+  ScheduledLectureFormat,
+  calculateHowLong,
+  calculateStartPoint,
+} from "../utils/format";
+import { useContext } from "react";
+import { DragAndDropContext } from "../context/DragAndDrop";
 
 interface Props {
   scheduledLectures?: ScheduledLectureFormat[];
@@ -8,8 +14,8 @@ interface Props {
 }
 
 interface TableCellProps {
-  howLong: number;
-  startPoint: number;
+  howlong: number;
+  startpoint: number;
 }
 
 export default function TableCell({
@@ -17,37 +23,22 @@ export default function TableCell({
   hourIndex,
   dayIndex,
 }: Props) {
-  const calculateStartPoint = (lecture: ScheduledLectureFormat) => {
-    const startMinutes = lecture.startMinutes;
-    const startPoint = startMinutes === 0 ? 0 : 50;
-
-    return startPoint;
-  };
-
-  const calculateHowLong = (lecture: ScheduledLectureFormat) => {
-    const endMinutes = lecture.endMinutes;
-    const endHour = lecture.endHour;
-    const startMinutes = lecture.startMinutes;
-    const startHour = lecture.startHour;
-
-    const howLong =
-      endMinutes - startMinutes === 0
-        ? endHour - startHour
-        : endMinutes - startMinutes > 0
-        ? endHour - startHour + 0.5
-        : endHour - startHour - 0.5;
-
-    return howLong;
-  };
+  const { handleDragStart } = useContext(DragAndDropContext);
 
   return (
     <>
-      {scheduledLectures?.map((lecture) => {
+      {scheduledLectures?.map((lecture, i) => {
         return lecture.startHour === hourIndex + 6 &&
           lecture.weekDayID === dayIndex + 1 ? (
           <TableCellStyled
-            howLong={calculateHowLong(lecture)}
-            startPoint={calculateStartPoint(lecture)}
+            key={i}
+            howlong={calculateHowLong(lecture)}
+            startpoint={calculateStartPoint(lecture)}
+            draggable={true}
+            onDragStart={handleDragStart({
+              howLong: calculateHowLong(lecture),
+              lectureID: lecture.lectureID,
+            })}
           >
             {lecture.title}
           </TableCellStyled>
@@ -61,10 +52,11 @@ const TableCellStyled = styled.div<TableCellProps>`
   width: 100%;
   position: absolute;
   background-color: gainsboro;
-  height: ${(props) => 50 * props.howLong}px;
-  top: ${(props) => props.startPoint}%;
+  height: ${(props) => 50 * props.howlong}px;
+  top: ${(props) => props.startpoint}%;
   right: 0;
+  z-index: 999;
   display: flex;
-  align-items: center;
   justify-content: center;
+  align-items: center;
 `;

--- a/src/components/TableContainer.tsx
+++ b/src/components/TableContainer.tsx
@@ -1,11 +1,46 @@
+import styled from "styled-components";
+import { FaRegTrashCan } from "react-icons/fa6";
+import { DragAndDropContext } from "../context/DragAndDrop";
+import { useContext, useEffect } from "react";
+
+import { useQueryClient } from "react-query";
+import { fetchDeleteScheduled } from "../api/scheduled.api";
+
 interface Props {
   children: React.ReactNode;
 }
 export default function TableContainer({ children }: Props) {
+  const { handleDropDelete, handleDragOver, dropDataDelete } =
+    useContext(DragAndDropContext);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const deleteSchedule = async () => {
+      await fetchDeleteScheduled(dropDataDelete.lectureID);
+      queryClient.invalidateQueries("schedules");
+      alert("삭제되었습니다.");
+    };
+    if (dropDataDelete.lectureID) {
+      deleteSchedule();
+    }
+  }, [dropDataDelete]);
+
   return (
-    <>
-      <h2>내 시간표</h2>
+    <StyledTableContainer>
+      <div className="header">
+        <h2>내 시간표</h2>
+        <h2 onDrop={handleDropDelete} onDragOver={handleDragOver}>
+          <FaRegTrashCan />
+        </h2>
+      </div>
+
       <table>{children}</table>
-    </>
+    </StyledTableContainer>
   );
 }
+const StyledTableContainer = styled.div`
+  .header {
+    display: flex;
+    justify-content: space-between;
+  }
+`;

--- a/src/components/TableContents.tsx
+++ b/src/components/TableContents.tsx
@@ -1,28 +1,90 @@
-import { ScheduledLectureFormat } from "../utils/format";
+import { useContext } from "react";
+import { ScheduledLectureFormat, formatStartEnd } from "../utils/format";
 import TableCell from "./TableCell";
+import { DragAndDropContext } from "../context/DragAndDrop";
+import styled from "styled-components";
+
+import { Modal } from "./common/Modal";
+import Button from "./common/Button";
+import { fetchUpdateScheduled } from "../api/scheduled.api";
+import { QueryClient, useQueryClient } from "react-query";
+import ScheduleModal from "./ScheduleModal";
 
 interface Props {
   schedule: string[][];
   scheduledLectures?: ScheduledLectureFormat[];
 }
 
+export interface UpdateProps {
+  startAt: string;
+  endAt: string;
+  weekDayID: number;
+  lectureID: number;
+}
+
 export default function TableContents({ schedule, scheduledLectures }: Props) {
+  const {
+    handleDragLeave,
+    handleDragOver,
+    handleDrop,
+    isOpen,
+    onClose,
+    dropData,
+  } = useContext(DragAndDropContext);
+
+  const queryClient = useQueryClient();
+
+  const handleClick = async (event: any) => {
+    const minute = event.target.value;
+    try {
+      const [startAt, endAt] = formatStartEnd(dropData, minute);
+      const data = {
+        startAt: startAt,
+        endAt: endAt,
+        weekDayID: dropData.weekDayID,
+        lectureID: dropData.lectureID,
+      };
+      await fetchUpdateScheduled(data);
+      queryClient.invalidateQueries("schedules");
+      onClose();
+    } catch (error: any) {
+      alert(error.message);
+      onClose();
+    }
+  };
+
   return (
-    <tbody>
-      {Array.from({ length: 18 }).map((_, hourIndex) => (
-        <tr key={hourIndex}>
-          <td>{`${hourIndex + 6}:00`}</td>
-          {schedule[hourIndex].map((lecture, dayIndex) => (
-            <td key={dayIndex}>
-              <TableCell
-                scheduledLectures={scheduledLectures}
-                hourIndex={hourIndex}
-                dayIndex={dayIndex}
-              />
-            </td>
-          ))}
-        </tr>
-      ))}
-    </tbody>
+    <>
+      {isOpen && (
+        <ScheduleModal
+          isOpen={isOpen}
+          onClose={onClose}
+          isSchedule={false}
+          handleClick={handleClick}
+        />
+      )}
+
+      <tbody>
+        {Array.from({ length: 18 }).map((_, hourIndex) => (
+          <tr key={hourIndex}>
+            <td>{`${hourIndex + 6}:00`}</td>
+            {schedule[hourIndex].map((lecture, dayIndex) => (
+              <td
+                key={dayIndex}
+                onDragLeave={handleDragLeave}
+                onDragOver={handleDragOver}
+                onDrop={handleDrop(hourIndex + 6, dayIndex + 1)}
+              >
+                <TableCell
+                  scheduledLectures={scheduledLectures}
+                  hourIndex={hourIndex}
+                  dayIndex={dayIndex}
+                />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </>
   );
 }

--- a/src/components/TableContents.tsx
+++ b/src/components/TableContents.tsx
@@ -24,8 +24,8 @@ export default function TableContents({ schedule, scheduledLectures }: Props) {
   const queryClient = useQueryClient();
 
   const handleClick = async (event: any) => {
-    const minute = event.target.value;
     try {
+      const minute = event.target.value;
       const [startAt, endAt] = formatStartEnd(dropData, minute);
       const data = {
         startAt: startAt,
@@ -33,16 +33,15 @@ export default function TableContents({ schedule, scheduledLectures }: Props) {
         weekDayID: dropData.weekDayID,
         lectureID: dropData.lectureID,
       };
-      console.log(data);
       await fetchUpdateScheduled(data);
       queryClient.invalidateQueries("schedules");
       onClose();
-    } catch (error: any) {
+    } catch (error) {
       alert(error);
       onClose();
     }
   };
-
+  console.log();
   return (
     <>
       {isOpen && (

--- a/src/components/TableContents.tsx
+++ b/src/components/TableContents.tsx
@@ -2,12 +2,8 @@ import { useContext } from "react";
 import { ScheduledLectureFormat, formatStartEnd } from "../utils/format";
 import TableCell from "./TableCell";
 import { DragAndDropContext } from "../context/DragAndDrop";
-import styled from "styled-components";
-
-import { Modal } from "./common/Modal";
-import Button from "./common/Button";
 import { fetchUpdateScheduled } from "../api/scheduled.api";
-import { QueryClient, useQueryClient } from "react-query";
+import { useQueryClient } from "react-query";
 import ScheduleModal from "./ScheduleModal";
 
 interface Props {
@@ -23,15 +19,8 @@ export interface UpdateProps {
 }
 
 export default function TableContents({ schedule, scheduledLectures }: Props) {
-  const {
-    handleDragLeave,
-    handleDragOver,
-    handleDrop,
-    isOpen,
-    onClose,
-    dropData,
-  } = useContext(DragAndDropContext);
-
+  const { handleDragOver, handleDrop, isOpen, onClose, dropData } =
+    useContext(DragAndDropContext);
   const queryClient = useQueryClient();
 
   const handleClick = async (event: any) => {
@@ -44,11 +33,12 @@ export default function TableContents({ schedule, scheduledLectures }: Props) {
         weekDayID: dropData.weekDayID,
         lectureID: dropData.lectureID,
       };
+      console.log(data);
       await fetchUpdateScheduled(data);
       queryClient.invalidateQueries("schedules");
       onClose();
     } catch (error: any) {
-      alert(error.message);
+      alert(error);
       onClose();
     }
   };
@@ -71,12 +61,13 @@ export default function TableContents({ schedule, scheduledLectures }: Props) {
             {schedule[hourIndex].map((lecture, dayIndex) => (
               <td
                 key={dayIndex}
-                onDragLeave={handleDragLeave}
                 onDragOver={handleDragOver}
                 onDrop={handleDrop(hourIndex + 6, dayIndex + 1)}
               >
                 <TableCell
-                  scheduledLectures={scheduledLectures}
+                  scheduledLectures={
+                    scheduledLectures === undefined ? [] : scheduledLectures
+                  }
                   hourIndex={hourIndex}
                   dayIndex={dayIndex}
                 />

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -8,9 +8,10 @@ interface Props {
   children: ReactNode;
   isOpen: boolean;
   onClose: () => void;
+  isSchedule?: boolean;
 }
 
-export const Modal = ({ children, isOpen, onClose }: Props) => {
+export const Modal = ({ children, isOpen, onClose, isSchedule }: Props) => {
   const [isFadingOut, setIsFadingOut] = useState(false);
 
   const modalRef = useRef<HTMLDivElement | null>(null);
@@ -56,9 +57,11 @@ export const Modal = ({ children, isOpen, onClose }: Props) => {
     >
       <div className="modal-body" ref={modalRef}>
         <div className="modal-content">{children}</div>
-        <button className="modal-close" onClick={handleClose}>
-          <FaPlus />
-        </button>
+        {!isSchedule && (
+          <button className="modal-close" onClick={handleClose}>
+            <FaPlus />
+          </button>
+        )}
       </div>
     </ModalStyle>,
     document.body

--- a/src/context/DragAndDrop.tsx
+++ b/src/context/DragAndDrop.tsx
@@ -1,20 +1,9 @@
-import { createContext, useState } from "react";
+import React, { createContext, useState } from "react";
 
 interface Props {
   children: React.ReactNode;
 }
 
-interface State {
-  handleDragStart: any;
-  handleDragOver: any;
-  handleDrop: any;
-  handleDragLeave: any;
-  handleDropDelete: any;
-  isOpen: boolean;
-  onClose: () => void;
-  dropData: UpdateProps;
-  dropDataDelete: DeleteProps;
-}
 export interface UpdateProps {
   howLong: number;
   lectureID: number;
@@ -26,12 +15,31 @@ export interface DeleteProps {
   lectureID: number;
 }
 
+interface State {
+  handleDragStart: (
+    data: UpdateProps
+  ) => (event: React.DragEvent<HTMLDivElement>) => void;
+  handleDragOver: (
+    event: React.DragEvent<HTMLTableCellElement>
+  ) => void | ((event: React.DragEvent<HTMLHeadElement>) => void);
+  handleDrop: (
+    startAt: number,
+    dayIndex: number
+  ) => (
+    event: React.DragEvent<HTMLTableCellElement>
+  ) => void | ((event: React.DragEvent<HTMLHeadingElement>) => void);
+  handleDropDelete: (event: React.DragEvent<HTMLTableCellElement>) => void;
+  isOpen: boolean;
+  onClose: () => void;
+  dropData: UpdateProps;
+  dropDataDelete: DeleteProps;
+}
+
 export const state = {
   handleDragStart: () => () => {},
   handleDragOver: () => {},
   handleDrop: () => () => {},
   handleDropDelete: () => {},
-  handleDragLeave: () => {},
   isOpen: false,
   onClose: () => {},
   dropData: {
@@ -60,35 +68,38 @@ const dropsDelete = {
 export const DragAndDropContext = createContext<State>(state);
 
 export const DragAndDropProvider = ({ children }: Props) => {
-  const handleDragStart =
-    (data: UpdateProps) => (event: React.DragEvent<HTMLLIElement>) => {
-      event.dataTransfer?.setData("text/plain", JSON.stringify(data));
-    };
-
-  const handleDragOver = (event: any) => {
-    event.preventDefault(); // 드롭 가능 영역으로 설정
-  };
-
   const [dropData, setDropData] = useState<UpdateProps>(drops);
   const [dropDataDelete, setDropDataDelete] =
     useState<DeleteProps>(dropsDelete);
-  const handleDrop = (startAt: number, dayIndex: number) => (event: any) => {
-    event.preventDefault();
-    onOpen();
-    const getDropData = JSON.parse(event.dataTransfer.getData("text/plain"));
-    getDropData.startAt = startAt;
-    getDropData.weekDayID = dayIndex;
-    setDropData(getDropData);
+
+  const handleDragStart =
+    (data: UpdateProps) => (event: React.DragEvent<HTMLDivElement>) => {
+      event.dataTransfer?.setData("text/plain", JSON.stringify(data));
+    };
+
+  const handleDragOver = (
+    event:
+      | React.DragEvent<HTMLTableCellElement>
+      | React.DragEvent<HTMLHeadElement>
+  ) => {
+    event.preventDefault(); // 드롭 가능 영역으로 설정
   };
 
-  const handleDropDelete = (event: any) => {
+  const handleDrop =
+    (startAt: number, dayIndex: number) =>
+    (event: React.DragEvent<HTMLTableCellElement>) => {
+      onOpen();
+      event.preventDefault();
+      const getDropData = JSON.parse(event.dataTransfer.getData("text/plain"));
+      getDropData.startAt = startAt;
+      getDropData.weekDayID = dayIndex;
+      setDropData(getDropData);
+    };
+
+  const handleDropDelete = (event: React.DragEvent<HTMLHeadElement>) => {
     event.preventDefault();
     const getDropData = JSON.parse(event.dataTransfer.getData("text/plain"));
     setDropDataDelete(getDropData);
-  };
-
-  const handleDragLeave = (event: any) => {
-    event.preventDefault();
   };
 
   const [isOpen, setIsOpen] = useState(false);
@@ -105,7 +116,6 @@ export const DragAndDropProvider = ({ children }: Props) => {
       value={{
         handleDragStart,
         handleDragOver,
-        handleDragLeave,
         handleDrop,
         handleDropDelete,
         isOpen,

--- a/src/context/DragAndDrop.tsx
+++ b/src/context/DragAndDrop.tsx
@@ -33,6 +33,7 @@ interface State {
   onClose: () => void;
   dropData: UpdateProps;
   dropDataDelete: DeleteProps;
+  isDraging: boolean;
 }
 
 export const state = {
@@ -52,6 +53,7 @@ export const state = {
     howLong: 0,
     lectureID: 0,
   },
+  isDraging: false,
 };
 
 const drops = {
@@ -71,6 +73,14 @@ export const DragAndDropProvider = ({ children }: Props) => {
   const [dropData, setDropData] = useState<UpdateProps>(drops);
   const [dropDataDelete, setDropDataDelete] =
     useState<DeleteProps>(dropsDelete);
+  const [isOpen, setIsOpen] = useState(false);
+  const onOpen = () => {
+    setIsOpen(true);
+  };
+  const onClose = () => {
+    setIsOpen(false);
+  };
+  const [isDraging, setIsDraging] = useState(false);
 
   const handleDragStart =
     (data: UpdateProps) => (event: React.DragEvent<HTMLDivElement>) => {
@@ -83,32 +93,25 @@ export const DragAndDropProvider = ({ children }: Props) => {
       | React.DragEvent<HTMLHeadElement>
   ) => {
     event.preventDefault(); // 드롭 가능 영역으로 설정
+    setIsDraging(true);
   };
 
   const handleDrop =
     (startAt: number, dayIndex: number) =>
     (event: React.DragEvent<HTMLTableCellElement>) => {
       onOpen();
-      event.preventDefault();
+      event.stopPropagation();
       const getDropData = JSON.parse(event.dataTransfer.getData("text/plain"));
       getDropData.startAt = startAt;
       getDropData.weekDayID = dayIndex;
       setDropData(getDropData);
+      setIsDraging(false);
     };
 
   const handleDropDelete = (event: React.DragEvent<HTMLHeadElement>) => {
     event.preventDefault();
     const getDropData = JSON.parse(event.dataTransfer.getData("text/plain"));
     setDropDataDelete(getDropData);
-  };
-
-  const [isOpen, setIsOpen] = useState(false);
-
-  const onOpen = () => {
-    setIsOpen(true);
-  };
-  const onClose = () => {
-    setIsOpen(false);
   };
 
   return (
@@ -122,6 +125,7 @@ export const DragAndDropProvider = ({ children }: Props) => {
         onClose,
         dropData,
         dropDataDelete,
+        isDraging,
       }}
     >
       {children}

--- a/src/context/DragAndDrop.tsx
+++ b/src/context/DragAndDrop.tsx
@@ -1,0 +1,120 @@
+import { createContext, useState } from "react";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  handleDragStart: any;
+  handleDragOver: any;
+  handleDrop: any;
+  handleDragLeave: any;
+  handleDropDelete: any;
+  isOpen: boolean;
+  onClose: () => void;
+  dropData: UpdateProps;
+  dropDataDelete: DeleteProps;
+}
+export interface UpdateProps {
+  howLong: number;
+  lectureID: number;
+  weekDayID: number;
+  startAt: number;
+}
+export interface DeleteProps {
+  howLong: number;
+  lectureID: number;
+}
+
+export const state = {
+  handleDragStart: () => () => {},
+  handleDragOver: () => {},
+  handleDrop: () => () => {},
+  handleDropDelete: () => {},
+  handleDragLeave: () => {},
+  isOpen: false,
+  onClose: () => {},
+  dropData: {
+    howLong: 0,
+    lectureID: 0,
+    weekDayID: 0,
+    startAt: 0,
+  },
+  dropDataDelete: {
+    howLong: 0,
+    lectureID: 0,
+  },
+};
+
+const drops = {
+  weekDayID: 0,
+  howLong: 0,
+  lectureID: 0,
+  startAt: 0,
+};
+const dropsDelete = {
+  howLong: 0,
+  lectureID: 0,
+};
+
+export const DragAndDropContext = createContext<State>(state);
+
+export const DragAndDropProvider = ({ children }: Props) => {
+  const handleDragStart =
+    (data: UpdateProps) => (event: React.DragEvent<HTMLLIElement>) => {
+      event.dataTransfer?.setData("text/plain", JSON.stringify(data));
+    };
+
+  const handleDragOver = (event: any) => {
+    event.preventDefault(); // 드롭 가능 영역으로 설정
+  };
+
+  const [dropData, setDropData] = useState<UpdateProps>(drops);
+  const [dropDataDelete, setDropDataDelete] =
+    useState<DeleteProps>(dropsDelete);
+  const handleDrop = (startAt: number, dayIndex: number) => (event: any) => {
+    event.preventDefault();
+    onOpen();
+    const getDropData = JSON.parse(event.dataTransfer.getData("text/plain"));
+    getDropData.startAt = startAt;
+    getDropData.weekDayID = dayIndex;
+    setDropData(getDropData);
+  };
+
+  const handleDropDelete = (event: any) => {
+    event.preventDefault();
+    const getDropData = JSON.parse(event.dataTransfer.getData("text/plain"));
+    setDropDataDelete(getDropData);
+  };
+
+  const handleDragLeave = (event: any) => {
+    event.preventDefault();
+  };
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onOpen = () => {
+    setIsOpen(true);
+  };
+  const onClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <DragAndDropContext.Provider
+      value={{
+        handleDragStart,
+        handleDragOver,
+        handleDragLeave,
+        handleDrop,
+        handleDropDelete,
+        isOpen,
+        onClose,
+        dropData,
+        dropDataDelete,
+      }}
+    >
+      {children}
+    </DragAndDropContext.Provider>
+  );
+};

--- a/src/hooks/useSchedules.ts
+++ b/src/hooks/useSchedules.ts
@@ -5,16 +5,20 @@ import { useQuery } from "react-query";
 
 export const useSchedules = (): {
   scheduledLectures: ScheduledLectureFormat[];
+  isScheduled: any;
 } => {
   const { data, isLoading } = useQuery("schedules", fetchScheduledLectures);
 
   try {
     const currentScheduledLectures = data?.data;
     const scheduledLectures = formatScheduled(currentScheduledLectures);
-    return { scheduledLectures };
+    const isScheduled = (id: number) => {
+      return scheduledLectures?.some((lecture) => lecture.lectureID === id);
+    };
+    return { scheduledLectures, isScheduled };
   } catch (error) {
     console.log(error);
   }
 
-  return { scheduledLectures: [] };
+  return { scheduledLectures: [], isScheduled: 1 };
 };

--- a/src/hooks/useSchedules.ts
+++ b/src/hooks/useSchedules.ts
@@ -2,24 +2,29 @@ import { tr } from "@faker-js/faker";
 import { fetchScheduledLectures } from "../api/schedule.api";
 import { ScheduledLectureFormat, formatScheduled } from "../utils/format";
 import { useQuery } from "react-query";
+import { useAuthStore } from "../store/authStore";
+import { useEffect, useState } from "react";
+import { fetchGetScheduled } from "../api/scheduled.api";
 
-export const useSchedules = (): {
-  scheduledLectures: ScheduledLectureFormat[];
-  isScheduled: (id: number) => boolean;
-} => {
-  const { data, isLoading } = useQuery("schedules", fetchScheduledLectures);
+export const useSchedules = () => {
+  const { isLoggedIn } = useAuthStore();
+  const [scheduledLectures, setScheduledLectures] = useState<
+    ScheduledLectureFormat[]
+  >([]);
 
-  try {
-    const currentScheduledLectures = data?.data;
-    const scheduledLectures = formatScheduled(currentScheduledLectures);
-    const isScheduled = (id: number) => {
-      return scheduledLectures?.some((lecture) => lecture.lectureID === id);
-    };
+  const isScheduled = (id: number) => {
+    return scheduledLectures?.some((lecture) => lecture.lectureID === id);
+  };
+  const { data, isLoading } = useQuery<ScheduledLectureFormat[]>(
+    "schedules",
+    fetchGetScheduled
+  );
 
-    return { scheduledLectures, isScheduled };
-  } catch (error) {
-    console.log(error);
-  }
+  useEffect(() => {
+    if (data) {
+      setScheduledLectures(formatScheduled(data));
+    }
+  }, [data]);
 
-  return { scheduledLectures: [], isScheduled: () => true };
+  return { scheduledLectures, isScheduled };
 };

--- a/src/hooks/useSchedules.ts
+++ b/src/hooks/useSchedules.ts
@@ -1,28 +1,20 @@
 import { useEffect, useState } from "react";
 import { fetchScheduledLectures } from "../api/schedule.api";
 import { ScheduledLectureFormat, formatScheduled } from "../utils/format";
+import { useQuery } from "react-query";
 
-export const useSchedules = () => {
-  const [scheduledLectures, setScheduledLectures] =
-    useState<ScheduledLectureFormat[]>();
+export const useSchedules = (): {
+  scheduledLectures: ScheduledLectureFormat[];
+} => {
+  const { data, isLoading } = useQuery("schedules", fetchScheduledLectures);
 
-  const isScheduled = (id: number) => {
-    return scheduledLectures?.some((lecture) => lecture.lectureID === id);
-  };
+  try {
+    const currentScheduledLectures = data?.data;
+    const scheduledLectures = formatScheduled(currentScheduledLectures);
+    return { scheduledLectures };
+  } catch (error) {
+    console.log(error);
+  }
 
-  useEffect(() => {
-    const handleScheduledLectures = async () => {
-      const response = await fetchScheduledLectures();
-      const currentScheduledLectures = response.data;
-      const currentFormatScheduledLectures = formatScheduled(
-        currentScheduledLectures
-      );
-
-      setScheduledLectures(currentFormatScheduledLectures);
-    };
-
-    handleScheduledLectures();
-  }, []);
-
-  return { scheduledLectures, isScheduled };
+  return { scheduledLectures: [] };
 };

--- a/src/hooks/useSchedules.ts
+++ b/src/hooks/useSchedules.ts
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { tr } from "@faker-js/faker";
 import { fetchScheduledLectures } from "../api/schedule.api";
 import { ScheduledLectureFormat, formatScheduled } from "../utils/format";
 import { useQuery } from "react-query";
 
 export const useSchedules = (): {
   scheduledLectures: ScheduledLectureFormat[];
-  isScheduled: any;
+  isScheduled: (id: number) => boolean;
 } => {
   const { data, isLoading } = useQuery("schedules", fetchScheduledLectures);
 
@@ -15,10 +15,11 @@ export const useSchedules = (): {
     const isScheduled = (id: number) => {
       return scheduledLectures?.some((lecture) => lecture.lectureID === id);
     };
+
     return { scheduledLectures, isScheduled };
   } catch (error) {
     console.log(error);
   }
 
-  return { scheduledLectures: [], isScheduled: 1 };
+  return { scheduledLectures: [], isScheduled: () => true };
 };

--- a/src/hooks/useSelected.ts
+++ b/src/hooks/useSelected.ts
@@ -50,7 +50,6 @@ export const useSelected = () => {
 
   useEffect(() => {
     getSelected();
-    console.log("호출");
   }, []);
 
   return { selectedLectures, isSelected, addSelected, deleteSelected };

--- a/src/hooks/useSelected.ts
+++ b/src/hooks/useSelected.ts
@@ -40,7 +40,7 @@ export const useSelected = () => {
     }
   };
 
-  const getSelected = async () => {
+  const getSelected = () => {
     if (isLoggedIn) {
       fetchGetSelected().then((items) => {
         setSelectedLectures(items);
@@ -50,6 +50,7 @@ export const useSelected = () => {
 
   useEffect(() => {
     getSelected();
+    console.log("호출");
   }, []);
 
   return { selectedLectures, isSelected, addSelected, deleteSelected };

--- a/src/models/scheduled.model.ts
+++ b/src/models/scheduled.model.ts
@@ -1,9 +1,9 @@
 export interface ScheduledLecture {
   lectureID?: number;
   scheduledLectureID?: number;
-  selectedLectureID: number;
+  selectedLectureID?: number;
   weekDayID: number;
   startAt: string;
   endAt: string;
-  title: string;
+  title?: string;
 }

--- a/src/models/scheduled.model.ts
+++ b/src/models/scheduled.model.ts
@@ -1,5 +1,5 @@
 export interface ScheduledLecture {
-  lectureID?: number;
+  lectureID: number;
   scheduledLectureID?: number;
   selectedLectureID?: number;
   weekDayID: number;

--- a/src/pages/MyLectures.tsx
+++ b/src/pages/MyLectures.tsx
@@ -1,26 +1,15 @@
 import styled from "styled-components";
 import MyLectureList from "../components/MyLectureList";
 import MyTimeTable from "../components/MyTimeTable";
-import { Lecture } from "../models/lecture.model";
-import { useState } from "react";
+import { DragAndDropProvider } from "../context/DragAndDrop";
+
+interface Props {
+  weekDayID: number;
+  startAt: number;
+  endAt: number;
+}
 
 export default function MyLectures() {
-  const [draggedItem, setDraggedItem] = useState<Lecture | null>(null);
-
-  const handleDragStart =
-    (title: string) => (event: React.DragEvent<HTMLLIElement>) => {
-      event.dataTransfer?.setData("text/plain", title);
-      console.log(title);
-    };
-
-  const handleDragOver = (event: React.DragEvent<HTMLTableCellElement>) => {
-    event.preventDefault(); // 드롭 가능 영역으로 설정
-  };
-
-  const handleDrop = () => (event: React.DragEvent<HTMLTableCellElement>) => {
-    const title = event.dataTransfer.getData("text/plain");
-  };
-
   return (
     <MyLecturesStyle>
       <div className="description">
@@ -28,11 +17,9 @@ export default function MyLectures() {
       </div>
       <div className="tables">
         <MyLectureList />
-        <MyTimeTable
-          onDragStart={handleDragStart}
-          onDragOver={handleDragOver}
-          onDrop={handleDrop}
-        />
+        <DragAndDropProvider>
+          <MyTimeTable />
+        </DragAndDropProvider>
       </div>
     </MyLecturesStyle>
   );
@@ -41,7 +28,6 @@ export default function MyLectures() {
 const MyLecturesStyle = styled.div`
   display: flex;
   flex-direction: column;
-
   .tables {
     display: flex;
     justify-content: space-between;

--- a/src/pages/MyLectures.tsx
+++ b/src/pages/MyLectures.tsx
@@ -3,12 +3,6 @@ import MyLectureList from "../components/MyLectureList";
 import MyTimeTable from "../components/MyTimeTable";
 import { DragAndDropProvider } from "../context/DragAndDrop";
 
-interface Props {
-  weekDayID: number;
-  startAt: number;
-  endAt: number;
-}
-
 export default function MyLectures() {
   return (
     <MyLecturesStyle>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -68,6 +68,7 @@ export const formatStartEnd = (dropData: UpdateProps, minute: string) => {
       endMinute = 30;
     }
   }
+
   const startAt =
     String(startHour).padStart(2, "0") +
     ":" +
@@ -77,7 +78,7 @@ export const formatStartEnd = (dropData: UpdateProps, minute: string) => {
 
   const checkEndAt = endAt.split(`:`);
   if (
-    Number(checkEndAt[0]) >= 24 ||
+    Number(checkEndAt[0]) > 24 ||
     (Number(checkEndAt[0]) === 24 && Number(checkEndAt[1]) === 30)
   ) {
     throw new Error("스케줄 가능한 시간을 지켜주세요.");

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -64,6 +64,8 @@ export const formatStartEnd = (dropData: UpdateProps, minute: string) => {
     endHour = startHour + Math.floor(dropData.howLong);
     if (dropData.howLong % 2 !== 0) {
       endHour = endHour + 1;
+    } else if (dropData.howLong % 2 === 0) {
+      endMinute = 30;
     }
   }
   const startAt =

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,4 @@
+import { UpdateProps } from "../context/DragAndDrop";
 import { ScheduledLecture } from "../models/scheduled.model";
 
 export const formatSlicePagination = (
@@ -24,4 +25,61 @@ export const formatScheduled = (scheduledLectures: ScheduledLecture[]) => {
       endMinutes: parseInt(scheduledLecture.endAt.split(":")[1]),
     }));
   return formmatedScheduledLectures;
+};
+
+export const calculateStartPoint = (lecture: ScheduledLectureFormat) => {
+  const startMinutes = lecture.startMinutes;
+  const startPoint = startMinutes === 0 ? 0 : 50;
+
+  return startPoint;
+};
+
+export const calculateHowLong = (lecture: ScheduledLectureFormat) => {
+  const endMinutes = lecture.endMinutes;
+  const endHour = lecture.endHour;
+  const startMinutes = lecture.startMinutes;
+  const startHour = lecture.startHour;
+
+  const howlong =
+    endMinutes - startMinutes === 0
+      ? endHour - startHour
+      : endMinutes - startMinutes > 0
+      ? endHour - startHour + 0.5
+      : endHour - startHour - 0.5;
+
+  return howlong;
+};
+
+export const formatStartEnd = (dropData: UpdateProps, minute: string) => {
+  let [startHour, startMinute] = [dropData.startAt, 0];
+  let [endHour, endMinute] = [0, 0];
+
+  if (minute === "0") {
+    endHour = startHour + Math.floor(dropData.howLong);
+    if (dropData.howLong % 2 !== 0) {
+      endMinute = endMinute + 30;
+    }
+  } else if (minute === "0.5") {
+    startMinute = 30;
+    endHour = startHour + Math.floor(dropData.howLong);
+    if (dropData.howLong % 2 !== 0) {
+      endHour = endHour + 1;
+    }
+  }
+  const startAt =
+    String(startHour).padStart(2, "0") +
+    ":" +
+    String(startMinute).padStart(2, "0");
+  const endAt =
+    String(endHour).padStart(2, "0") + ":" + String(endMinute).padStart(2, "0");
+
+  const checkEndAt = endAt.split(`:`);
+  if (
+    Number(checkEndAt[0]) >= 24 ||
+    (Number(checkEndAt[0]) === 24 && Number(checkEndAt[1]) === 30)
+  ) {
+    throw new Error("스케줄 가능한 시간을 지켜주세요.");
+  }
+
+  return [startAt, endAt];
 };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

updown->main

### 변경 사항

> 1. Schedule update/delete fetcher 함수 개발
> 2. Drag And Drop으로 시간표를 수정/삭제 개발
> 3. React-Query로 fetching하여 데이터를 캐싱하고 수정/삭제와 동시에 UI에 반영되도록함
> 4. BASE_URL을 배포된 주소로 변경

## 개선할 점

>1. 동일한 강의가 동일한 날짜(목->목)으로 시간만 변경될 때(스케줄이 수정될때) 수정이 되지 않음 (동일한 시간에 이미 존재하는 강의가 있다고나온다.)
>2. 동일한 강의가 동일한 날짜으로 시간만 변경하기 위해 Drag하면 Drop되는 위치의 날짜데이터가 아닌 DragStart했을 때의 날짜데이터를 가져온다. (결국 동일한 시간에 이미 존재하는 강의가 있다고 나온다.) -> 이는 강의 시간이 길어지면 drop되는 위치의 <td>태그를 참조하는 게아닌 길어진 TableCell의 컴포넌트를 참조해서 발생하는 오류라고 생각된다.
>3. 스파게티 코드 개선
>4. DragOver중 시간표 테두리에 css를 적용하여 더 나은 UI/UX를 제공해야한다.

### 테스트 결과
<img width="1131" alt="스크린샷 2024-05-09 오전 11 20 28" src="https://github.com/ypg2/ypg2_front/assets/101778169/48cac233-b0df-4c82-af82-94c720aea24f">



