### PR TITLE
fix: Schedule Drag 중 동일한 weekDayID에서 더 큰 StartAt으로 옮길 때 (수정 할 때) 문제 해결

### DIFF
--- a/src/components/TableCell.tsx
+++ b/src/components/TableCell.tsx
@@ -4,10 +4,11 @@ import {
   calculateHowLong,
   calculateStartPoint,
 } from "../utils/format";
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { DragAndDropContext } from "../context/DragAndDrop";
+import { isCanPaintSchedule } from "../utils/scheduling";
 
-interface Props {
+export interface Props {
   scheduledLectures: ScheduledLectureFormat[];
   hourIndex: number;
   dayIndex: number;
@@ -23,7 +24,10 @@ export default function TableCell({
   hourIndex,
   dayIndex,
 }: Props) {
-  const { handleDragStart, isDraging } = useContext(DragAndDropContext);
+  // dayIndex,hourIndex,dragingPoint를 통해 해결할 수 있을듯
+  // dayIndex가 동일하고 hourIndex에서 howLong만큼 범위의 내에 있으면 해당 TableCellStyled는 안보이게함
+  const { handleDragStart, dragingPoint } = useContext(DragAndDropContext);
+
   const handleDragStartWrapper = (lecture: ScheduledLectureFormat) => {
     return (event: React.DragEvent<HTMLDivElement>) => {
       handleDragStart({
@@ -34,22 +38,27 @@ export default function TableCell({
       })(event);
     };
   };
+  if (!scheduledLectures) {
+    return null;
+  }
+  // 조건이 해당 isCanPaintSchedule
 
   return (
     <>
-      {scheduledLectures?.map((lecture, i) => {
-        return lecture.startHour === hourIndex + 6 &&
-          lecture.weekDayID === dayIndex + 1 ? (
-          <TableCellStyled
-            key={i}
-            howlong={calculateHowLong(lecture)}
-            startpoint={calculateStartPoint(lecture)}
-            draggable={true}
-            onDragStart={handleDragStartWrapper(lecture)}
-          >
-            {lecture.title}
-          </TableCellStyled>
-        ) : null;
+      {scheduledLectures.map((lecture, i) => {
+        return (
+          isCanPaintSchedule(lecture, dayIndex, hourIndex, dragingPoint) && (
+            <TableCellStyled
+              key={i}
+              howlong={calculateHowLong(lecture)}
+              startpoint={calculateStartPoint(lecture)}
+              draggable={true}
+              onDragStart={handleDragStartWrapper(lecture)}
+            >
+              {lecture.title}
+            </TableCellStyled>
+          )
+        );
       })}
     </>
   );

--- a/src/context/DragAndDrop.tsx
+++ b/src/context/DragAndDrop.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useState } from "react";
+import { debounce } from "lodash";
 
 interface Props {
   children: React.ReactNode;
@@ -33,7 +34,6 @@ interface State {
   onClose: () => void;
   dropData: UpdateProps;
   dropDataDelete: DeleteProps;
-  isDraging: boolean;
   dragingPoint: number[];
 }
 
@@ -75,7 +75,7 @@ export const DragAndDropProvider = ({ children }: Props) => {
   const [dropData, setDropData] = useState<UpdateProps>(drops);
   const [dropDataDelete, setDropDataDelete] =
     useState<DeleteProps>(dropsDelete);
-  const [dragingPoint, setDragingPoint] = useState<number[]>([]);
+  const [dragingPoint, setDragingPoint] = useState<number[]>([-1, -1]);
   const [isOpen, setIsOpen] = useState(false);
   const onOpen = () => {
     setIsOpen(true);
@@ -83,7 +83,6 @@ export const DragAndDropProvider = ({ children }: Props) => {
   const onClose = () => {
     setIsOpen(false);
   };
-  const [isDraging, setIsDraging] = useState(false);
   const [] = useState();
   const handleDragStart =
     (data: UpdateProps) => (event: React.DragEvent<HTMLDivElement>) => {
@@ -100,7 +99,6 @@ export const DragAndDropProvider = ({ children }: Props) => {
       .split(`,`)
       .map((item) => Number(item));
     setDragingPoint(dragPoint);
-    setIsDraging(true);
   };
 
   const handleDrop =
@@ -112,7 +110,6 @@ export const DragAndDropProvider = ({ children }: Props) => {
       getDropData.startAt = startAt;
       getDropData.weekDayID = dayIndex;
       setDropData(getDropData);
-      setIsDraging(false);
       setDragingPoint([-1, -1]);
     };
 
@@ -133,7 +130,6 @@ export const DragAndDropProvider = ({ children }: Props) => {
         onClose,
         dropData,
         dropDataDelete,
-        isDraging,
         dragingPoint,
       }}
     >

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -1,3 +1,5 @@
+import { ScheduledLectureFormat } from "./format";
+
 export const weekDays = [
   {
     id: 1,
@@ -40,4 +42,29 @@ export const generateTimeOptions = (startHour: number, endHour: number) => {
     times.push(timeString);
   }
   return times;
+};
+
+export const isCanPaintSchedule = (
+  lecture: ScheduledLectureFormat,
+  dayIndex: number,
+  hourIndex: number,
+  dragingPoint: number[]
+) => {
+  const [dragingDayIndex, dragingHourIndex] = dragingPoint;
+  const lectureStartHour = lecture.startHour;
+  const lectureEndHour = lecture.endHour;
+  const lectureWeekDayID = lecture.weekDayID;
+
+  if (lectureStartHour === hourIndex + 6 && lectureWeekDayID === dayIndex + 1) {
+    if (
+      dragingDayIndex + 1 === lectureWeekDayID &&
+      dragingHourIndex + 6 >= lectureStartHour &&
+      dragingHourIndex + 6 <= lectureEndHour
+    ) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+  return false;
 };


### PR DESCRIPTION
…겹쳐져 날짜 데이터가 이전의 데이터를 참조하는 문제 해결

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

updown -> main

### 변경 사항

> PR#14의 두 번째 개선점 해결
> Schedule Drag 중 동일한 weekDayID에서 더 큰 StartAt으로 옮길 때 (수정 할 때) UI상 겹쳐져 날짜 데이터가 이전의 데이터를 참조하는 문제 해결 

### 테스트 결과


https://github.com/ypg2/ypg2_front/assets/101778169/f9355d1b-4306-4a46-87ac-9ef3092cf9dd


